### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-01-31
+
+### Fixed
+
+- **Version Display**: Fix `codegeass --version` and dashboard API showing wrong version
+  - CLI version was hardcoded to 0.1.3, dashboard API was hardcoded to 1.0.0
+  - Now both read version dynamically from package metadata using `importlib.metadata`
+  - Single source of truth: `pyproject.toml`
+
 ## [0.2.2] - 2026-01-31
 
 ### Fixed
@@ -219,7 +228,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ANTHROPIC_API_KEY deliberately unset in CRON to use Pro/Max subscription
 - No API tokens in configuration files
 
-[Unreleased]: https://github.com/DonTizi/CodeGeass/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/DonTizi/CodeGeass/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/DonTizi/CodeGeass/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/DonTizi/CodeGeass/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/DonTizi/CodeGeass/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/DonTizi/CodeGeass/compare/v0.1.4...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codegeass"
-version = "0.2.2"
+version = "0.2.3"
 description = "Claude Code Scheduler Framework - Orchestrate automated Claude Code sessions"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/codegeass/__init__.py
+++ b/src/codegeass/__init__.py
@@ -4,7 +4,11 @@ Orchestrate automated Claude Code sessions with templates, prompts and skills,
 executed via CRON with your Pro/Max subscription.
 """
 
-__version__ = "0.1.3"
+try:
+    from importlib.metadata import version as _get_version
+    __version__ = _get_version("codegeass")
+except Exception:
+    __version__ = "unknown"  # fallback for editable installs without metadata
 
 from codegeass.core.entities import Skill, Task, Template
 from codegeass.core.value_objects import ExecutionResult, ExecutionStatus

--- a/src/codegeass/dashboard/main.py
+++ b/src/codegeass/dashboard/main.py
@@ -4,9 +4,16 @@ import asyncio
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import datetime
+from importlib.metadata import version as get_version
 from pathlib import Path
 
 from fastapi import FastAPI
+
+# Get version from package metadata (single source of truth: pyproject.toml)
+try:
+    _version = get_version("codegeass")
+except Exception:
+    _version = "unknown"
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -133,7 +140,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(
     title="CodeGeass Dashboard API",
     description="API for managing CodeGeass scheduled tasks",
-    version="1.0.0",
+    version=_version,
     lifespan=lifespan,
 )
 


### PR DESCRIPTION
## Summary
Fix version display - single source of truth from pyproject.toml

## Changes in v0.2.3

### Fixed
- **Version Display**: Fix `codegeass --version` and dashboard API showing wrong version
  - CLI version was hardcoded to 0.1.3, dashboard API was hardcoded to 1.0.0
  - Now both read version dynamically from package metadata using `importlib.metadata`
  - Single source of truth: `pyproject.toml`

## After Merge
Tag with `v0.2.3` to trigger PyPI release.